### PR TITLE
Bugfix update superuser

### DIFF
--- a/conf/create_superuser.py
+++ b/conf/create_superuser.py
@@ -11,10 +11,12 @@ def main():
         description='Create or update Django super user.'
     )
     parser.add_argument('--username')
+    parser.add_argument('--email')
     parser.add_argument('--password')
 
     args = parser.parse_args()
     username = args.username
+    email = args.email or ''
     password = args.password
 
     import django
@@ -26,12 +28,13 @@ def main():
     if super_user:
         print('Update existing super user and set his password.', file=sys.stderr)
         super_user.set_password(password)
+        super_user.email=email
         super_user.save()
     else:
         print('Create new super user', file=sys.stderr)
         User.objects.create_superuser(
             username=username,
-            email='',
+            email=email,
             password=password
         )
 

--- a/scripts/install
+++ b/scripts/install
@@ -120,6 +120,9 @@ chown -R "$app" "$final_path"
 # ================================================
 ynh_script_progression --message="Create pyinventory configuration file..."
 
+cp ../conf/create_superuser.py "$final_path/create_superuser.py"
+chmod +x "$final_path/create_superuser.py"
+
 gunicorn_conf="$final_path/gunicorn.conf.py"
 cp "../conf/gunicorn.conf.py" "$gunicorn_conf"
 ynh_replace_string --match_string="__FINAL_HOME_PATH__" --replace_string="$final_path" --target_file="$gunicorn_conf"
@@ -171,7 +174,7 @@ ynh_script_progression --message="migrate/collectstatic/createadmin..." --weight
 
 	./manage.py migrate --no-input
 	./manage.py collectstatic --no-input
-	echo "from django.contrib.auth import get_user_model; get_user_model().objects.create_superuser('$admin', '$admin_mail', 'pyinventory')" | ./manage.py shell
+	./create_superuser.py --username="$admin" --email="$admin_mail" --password="pyinventory"
 
 	# Check the configuration
 	# This may fail in some cases with errors, etc., but the app works and the user can fix issues later.

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -105,6 +105,10 @@ chown -R "$app" "$final_path"
 # ================================================
 ynh_script_progression --message="Create pyinventory configuration file..."
 
+ynh_backup_if_checksum_is_different --file="$final_path/create_superuser.py"
+cp ../conf/create_superuser.py "$final_path/create_superuser.py"
+chmod +x "$final_path/create_superuser.py"
+
 gunicorn_conf="$final_path/gunicorn.conf.py"
 ynh_backup_if_checksum_is_different --file="$gunicorn_conf"
 cp "../conf/gunicorn.conf.py" "$gunicorn_conf"
@@ -160,7 +164,7 @@ ynh_script_progression --message="migrate/collectstatic/createadmin..." --weight
 
 	./manage.py migrate --no-input
 	./manage.py collectstatic --no-input
-	echo "from django.contrib.auth import get_user_model; get_user_model().objects.create_superuser('$admin', '$admin_mail', 'pyinventory')" | ./manage.py shell
+	./create_superuser.py --username="$admin" --email="$admin_mail" --password="pyinventory"
 
 	# Check the configuration
 	# This may fail in some cases with errors, etc., but the app works and the user can fix issues later.


### PR DESCRIPTION
The "update superuser" part in "scripts/upgrade" doesn't work. Because it tries to create a new
superuser and doesn't handle a existing one.

We have conf/create_superuser.py that handle this: Use it in install/upgrade