### PR TITLE
fix logrotate call in upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -101,7 +101,7 @@ ynh_script_progression "Upgrading system configurations related to $app..."
 
 ynh_config_add_nginx
 ynh_config_add_systemd
-ynh_config_add_logrotate
+ynh_config_add_logrotate "$log_file"
 yunohost service add --description $app $app
 
 #=================================================


### PR DESCRIPTION
In install we do `ynh_config_add_logrotate "$log_file"` so the same in upgrade.

## Problem

- *Description of why you made this PR*

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
